### PR TITLE
feat: add daily spending total (Gasto del día) to budget summary card

### DIFF
--- a/components/BudgetSummaryCard.vue
+++ b/components/BudgetSummaryCard.vue
@@ -8,6 +8,7 @@ type Props = {
   remainingMonthlyBudget: number | null;
   monthlyBudgetLoading: boolean;
   remainingDailyBudget: number;
+  todayExpensesTotal: number;
 };
 
 const locale = 'es-AR';
@@ -64,6 +65,18 @@ const isEditing = ref(false);
             'text-success': remainingDailyBudget >= 0
           }">
             {{ remainingDailyBudget.toLocaleString(locale, { style: 'currency', currency: 'ARS' }) }}
+          </p>
+        </template>
+      </div>
+
+      <div class="flex flex-row gap-2 justify-between">
+        <p>Gasto del día:</p>
+        <template v-if="monthlyBudgetLoading">
+          <Skeleton class="w-[30%] h-10 rounded-full" />
+        </template>
+        <template v-else>
+          <p class="text-destructive-foreground">
+            {{ todayExpensesTotal.toLocaleString(locale, { style: 'currency', currency: 'ARS' }) }}
           </p>
         </template>
       </div>

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -34,6 +34,7 @@ const showExpenseForm = ref(false);
 const showDateSelector = ref(false);
 
 const getRemainingDailyBudget = computed(() => store.getRemainingDailyBudget);
+const getTodayExpensesTotal = computed(() => store.getTodayExpensesTotal);
 const expenses = computed(() => selectedBudget.value?.id ? getExpensesByBudgetId(selectedBudget.value?.id) : []);
 
 const handleAddExpense = () => {
@@ -73,7 +74,7 @@ onMounted(() => {
         <div class="flex flex-col md:flex-row gap-4 w-full order-1 md:order-none md:overflow-x-auto">
           <DateSelector className="hidden md:block" v-model:selectedDate="selectedDate" />
           <BudgetSummaryCard :remaining-monthly-budget="monthlyBudget ?? null" :monthly-budget-loading="monthlyBudgetLoading"
-            :remaining-daily-budget="getRemainingDailyBudget" />
+            :remaining-daily-budget="getRemainingDailyBudget" :today-expenses-total="getTodayExpensesTotal" />
           <ExpensesByCategoryList />
         </div>
       </div>

--- a/stores/expensesStore.ts
+++ b/stores/expensesStore.ts
@@ -54,6 +54,19 @@ export const useMyExpensesStore = defineStore("myExpensesStore", () => {
   });
 
   // Derived getters for budget calculations
+  const getTodayExpensesTotal = computed(() => {
+    const budgetStore = useMyBudgetStoreStore();
+    const selectedBudget = budgetStore.selectedBudget;
+
+    if (!selectedBudget?.id) return 0;
+
+    const budgetExpenses = expenses.value[selectedBudget.id] || [];
+    return budgetExpenses.reduce(
+      (sum, expense) => sum + Number(expense.amount),
+      0
+    );
+  });
+
   const getRemainingDailyBudget = computed(() => {
     // Access budget store within computed to avoid circular dependency
     const budgetStore = useMyBudgetStoreStore();
@@ -235,6 +248,7 @@ export const useMyExpensesStore = defineStore("myExpensesStore", () => {
     // Getters
     getExpensesByBudgetId,
     getRemainingDailyBudget,
+    getTodayExpensesTotal,
     getCategoryFromExpense,
     loading,
     // Actions


### PR DESCRIPTION
This pull request adds a new feature to display the total expenses for the current day in the budget summary card, improves currency formatting consistency, and updates the state management to support this new data. The changes affect both the UI components and the Vuex store.

**Feature: Display today's expenses in budget summary**

* Added a new prop `todayExpensesTotal` to the `BudgetSummaryCard` component and displayed the formatted total of today's expenses in the card, including a loading state. [[1]](diffhunk://#diff-5c2e887067be4c05584d176e88a2f956b271ff33148191267a49ec9e12c77d83R11-R15) [[2]](diffhunk://#diff-5c2e887067be4c05584d176e88a2f956b271ff33148191267a49ec9e12c77d83L66-R80)
* Updated the dashboard page to compute and pass `getTodayExpensesTotal` to the `BudgetSummaryCard` component. [[1]](diffhunk://#diff-45d6b13abae3bddada566ed22eb8a642d3a764dcc7d4a6c8af22ca15e28280d7R37) [[2]](diffhunk://#diff-45d6b13abae3bddada566ed22eb8a642d3a764dcc7d4a6c8af22ca15e28280d7L76-R77)

**Improvements: Currency formatting**

* Replaced inline currency formatting with the shared `formatCurrency` function for all budget amounts in `BudgetSummaryCard` to ensure consistency. [[1]](diffhunk://#diff-5c2e887067be4c05584d176e88a2f956b271ff33148191267a49ec9e12c77d83L51-R53) [[2]](diffhunk://#diff-5c2e887067be4c05584d176e88a2f956b271ff33148191267a49ec9e12c77d83L66-R80)

**State management: Store updates**

* Added a new computed getter `getTodayExpensesTotal` to the `expensesStore` to calculate the sum of today's expenses for the selected budget, and exported it for use in the UI. [[1]](diffhunk://#diff-3c1351c08f34aaa6147abbb89aff376ac5dfe7d6dcacb8b70a8079d62e808754R57-R69) [[2]](diffhunk://#diff-3c1351c08f34aaa6147abbb89aff376ac5dfe7d6dcacb8b70a8079d62e808754R251)